### PR TITLE
Add Spock tests for legal age and age calculation features  

### DIFF
--- a/base/src/main/java/lv/id/jc/person/PersonServiceImpl.java
+++ b/base/src/main/java/lv/id/jc/person/PersonServiceImpl.java
@@ -1,0 +1,18 @@
+package lv.id.jc.person;
+
+import java.time.LocalDate;
+
+public class PersonServiceImpl implements PersonService {
+    @Override
+    public boolean isLegalAge(Person person) {
+        return isLegalAge(age(person, LocalDate.now()));
+    }
+
+    int age(Person person, LocalDate today) {
+        throw new UnsupportedOperationException();
+    }
+
+    boolean isLegalAge(int age) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/base/src/test/groovy/lv/id/jc/person/AgeCalculationSpec.groovy
+++ b/base/src/test/groovy/lv/id/jc/person/AgeCalculationSpec.groovy
@@ -9,9 +9,7 @@ import java.time.LocalDate
 class AgeCalculationSpec extends Specification {
 
     @Subject
-    def sut = new Object() {
-        int age(Person person, LocalDate today) { 18 }
-    }
+    def sut = new PersonServiceImpl()
 
     @PendingFeature(reason = 'Scheduled in release 0.2')
     def "calculate the age: #comment"() {

--- a/base/src/test/groovy/lv/id/jc/person/AgeCalculationSpec.groovy
+++ b/base/src/test/groovy/lv/id/jc/person/AgeCalculationSpec.groovy
@@ -1,0 +1,37 @@
+package lv.id.jc.person
+
+import spock.lang.PendingFeature
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.LocalDate
+
+class AgeCalculationSpec extends Specification {
+
+    @Subject
+    def sut = new Object() {
+        int age(Person person, LocalDate today) { 18 }
+    }
+
+    @PendingFeature(reason = 'Scheduled in release 0.2')
+    def "calculate the age: #comment"() {
+        given:
+        def person = new Person(name, LocalDate.parse(birthday), [] as Set)
+
+        when:
+        def today = LocalDate.parse(now)
+
+        then:
+        sut.age(person, today) == expectedAge
+
+        where:
+        name      | birthday     | now          | expectedAge | comment
+        'Alice'   | '2005-10-01' | '2023-10-01' | 18          | 'Birthday is today'
+        'Bob'     | '1990-02-28' | '2023-02-27' | 32          | 'One day before birthday this year'
+        'Charlie' | '1985-06-15' | '2023-06-15' | 38          | 'Birthday is on the current date'
+        'Diana'   | '2000-12-31' | '2023-01-01' | 22          | 'Not reached birthday yet this year'
+        'Edward'  | '2010-07-01' | '2023-06-30' | 12          | 'Just one day before turning 13'
+        'Fiona'   | '1980-11-30' | '2023-11-30' | 43          | 'Birthday today'
+        'George'  | '1972-05-10' | '2023-05-09' | 50          | 'One day before turning 51'
+    }
+}

--- a/base/src/test/groovy/lv/id/jc/person/LegalAgeSpec.groovy
+++ b/base/src/test/groovy/lv/id/jc/person/LegalAgeSpec.groovy
@@ -1,0 +1,28 @@
+package lv.id.jc.person
+
+import spock.lang.PendingFeature
+import spock.lang.Specification
+import spock.lang.Subject
+
+class LegalAgeSpec extends Specification {
+
+    @Subject
+    def sut = new Object() {
+        boolean isLegalAge(int age) { true }
+    }
+
+    @PendingFeature(reason = 'Planned in release 0.2')
+    def 'determines whether the age is legal age'() {
+        expect:
+        sut.isLegalAge(age) == expected
+
+        where:
+        age | expected | comment
+        18  | true     | '18 is the boundary age for legal adulthood'
+        17  | false    | 'Below legal age boundary'
+        20  | true     | 'Above the legal age'
+        16  | false    | 'Well below the legal age'
+        21  | true     | 'Common benchmark for legal age in some regions'
+        0   | false    | 'Age must be greater than 0'
+    }
+}

--- a/base/src/test/groovy/lv/id/jc/person/LegalAgeSpec.groovy
+++ b/base/src/test/groovy/lv/id/jc/person/LegalAgeSpec.groovy
@@ -7,9 +7,7 @@ import spock.lang.Subject
 class LegalAgeSpec extends Specification {
 
     @Subject
-    def sut = new Object() {
-        boolean isLegalAge(int age) { true }
-    }
+    def sut = new PersonServiceImpl()
 
     @PendingFeature(reason = 'Planned in release 0.2')
     def 'determines whether the age is legal age'() {


### PR DESCRIPTION
### Description  
Introduces `LegalAgeSpec` and `AgeCalculationSpec` to test the logic for legal adulthood determination and age calculation. These tests are currently marked as pending and will be implemented in release 0.2. Data-driven examples have been added to ensure coverage of diverse scenarios.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced automated tests to validate accurate age calculations across various scenarios.
	- Added tests to verify correct determination of legal age using a range of age inputs.
	- Included pending feature tests for future implementation of age calculation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->